### PR TITLE
Add mobile touch controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,4 +12,7 @@ This repository contains an HTML5 game built with vanilla JavaScript.
 - Run the Node scripts in `tests/` before committing changes.
 - Assets live under `src/svg/` and `src/audio/`.
 - Use the root `.gitignore` to keep OS and editor artifacts out of version control.
+- Touch controls are wired in `bindTouchControls()` and rely on IDs defined in
+  `index.html`. Ensure any new controls keep to this pattern and maintain
+  responsive sizing via `resizeCanvas()`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.3.0] - 2025-07-11
+- Added responsive canvas sizing and mobile touch controls.
+- Documented new control scheme and added test stub for touch bindings.
+
 ## [0.2.0] - 2025-07-11
 - Added side-scrolling with expanded world size.
 - Introduced new resources and depth scaling.

--- a/POSTERITY.md
+++ b/POSTERITY.md
@@ -11,3 +11,9 @@ All code is organized within `src/` to keep the project tidy.
 ## Depth scaling and SVG assets
 Resource probabilities increase with depth to add challenge (see `generateWorld` in `src/game.js`). SVG images were chosen for tiles to keep the asset footprint small while allowing simple animations.
 
+## Mobile considerations
+Touch controls were added to broaden accessibility. Buttons overlay the canvas
+with semi-transparent styling so gameplay remains visible. Canvas dimensions are
+scaled via `resizeCanvas()` to maintain the original aspect ratio on any screen
+size.
+

--- a/README.md
+++ b/README.md
@@ -14,5 +14,13 @@ Open `index.html` in a modern browser to play.
 ```
 node tests/world.js
 node tests/upgrade.js
+node tests/touch.js
 ```
+
+## Mobile Controls
+
+Touch buttons overlay the canvas for movement and actions. Tap the arrows to move
+or dig and use the Refuel, Sell, and Upgrade buttons when standing on the
+appropriate tile. You can also tap adjacent tiles to move a single step in that
+direction.
 

--- a/index.html
+++ b/index.html
@@ -18,6 +18,20 @@
     <button id="continueGame">Continue</button>
   </div>
   <canvas id="gameCanvas" width="640" height="480"></canvas>
+  <div id="touch-controls">
+    <div class="arrows">
+      <button id="btn-up">&#8593;</button>
+      <button id="btn-left">&#8592;</button>
+      <button id="btn-down">&#8595;</button>
+      <button id="btn-right">&#8594;</button>
+    </div>
+    <div class="actions">
+      <button id="btn-dig">Dig</button>
+      <button id="btn-refuel">Refuel</button>
+      <button id="btn-sell">Sell</button>
+      <button id="btn-upgrade">Upgrade</button>
+    </div>
+  </div>
   <audio id="sndCollect" src="src/audio/collect.mp3" preload="auto"></audio>
   <audio id="sndDrill" src="src/audio/drill.mp3" preload="auto"></audio>
   <audio id="sndShop" src="src/audio/shop.mp3" preload="auto"></audio>

--- a/src/game.js
+++ b/src/game.js
@@ -78,6 +78,9 @@ class Game {
     this.loadProgress();
     this.initWorld();
     this.bindKeys();
+    this.bindTouchControls();
+    this.resizeCanvas();
+    window.addEventListener('resize', () => this.resizeCanvas());
     requestAnimationFrame(() => this.gameLoop());
   }
 
@@ -114,6 +117,65 @@ class Game {
           break;
       }
     });
+  }
+
+  bindTouchControls() {
+    const actions = {
+      'btn-left': () => this.move(-1, 0),
+      'btn-right': () => this.move(1, 0),
+      'btn-up': () => this.move(0, -1),
+      'btn-down': () => this.move(0, 1),
+      'btn-dig': () => this.move(0, 1),
+      'btn-refuel': () => this.refuel(),
+      'btn-sell': () => this.sell(),
+      'btn-upgrade': () => this.upgrade()
+    };
+    Object.keys(actions).forEach(id => {
+      const el = document.getElementById(id);
+      if (!el) return;
+      const handler = actions[id];
+      el.addEventListener('touchstart', e => {
+        e.preventDefault();
+        handler();
+      });
+      el.addEventListener('touchend', e => e.preventDefault());
+    });
+
+    this.canvas.addEventListener('pointerup', e => {
+      const rect = this.canvas.getBoundingClientRect();
+      const scaleX = this.canvas.width / rect.width;
+      const scaleY = this.canvas.height / rect.height;
+      const cx = Math.floor((e.clientX - rect.left) * scaleX / tileSize);
+      const cy = Math.floor((e.clientY - rect.top) * scaleY / tileSize);
+      const startX = Math.min(
+        worldWidth - viewWidth,
+        Math.max(0, this.player.x - Math.floor(viewWidth / 2))
+      );
+      const startY = Math.min(
+        worldHeight - viewHeight,
+        Math.max(0, this.player.y - Math.floor(viewHeight / 2))
+      );
+      const tx = startX + cx;
+      const ty = startY + cy;
+      const dx = tx - this.player.x;
+      const dy = ty - this.player.y;
+      if (Math.abs(dx) + Math.abs(dy) === 1) {
+        this.move(dx, dy);
+      }
+    });
+  }
+
+  resizeCanvas() {
+    const ratio = viewWidth / viewHeight;
+    let width = window.innerWidth;
+    let height = window.innerHeight;
+    if (width / height > ratio) {
+      width = height * ratio;
+    } else {
+      height = width / ratio;
+    }
+    this.canvas.style.width = `${width}px`;
+    this.canvas.style.height = `${height}px`;
   }
 
   move(dx, dy) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -19,3 +19,53 @@ body {
 #menu {
   margin: 8px;
 }
+
+#touch-controls {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+#touch-controls button {
+  background: rgba(255, 255, 255, 0.5);
+  border: 1px solid #fff;
+  padding: 6px 8px;
+  color: #000;
+  pointer-events: all;
+}
+
+#touch-controls .arrows {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  display: grid;
+  grid-template-areas:
+    '. up .'
+    'left down right';
+  gap: 4px;
+}
+
+#btn-up {
+  grid-area: up;
+}
+#btn-left {
+  grid-area: left;
+}
+#btn-down {
+  grid-area: down;
+}
+#btn-right {
+  grid-area: right;
+}
+
+#touch-controls .actions {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}

--- a/tests/touch.js
+++ b/tests/touch.js
@@ -1,0 +1,27 @@
+// stub document and window before requiring game code
+const created = {};
+['btn-left','btn-right','btn-up','btn-down','btn-dig','btn-refuel','btn-sell','btn-upgrade'].forEach(id => {
+  created[id] = { addEventListener: () => {} };
+});
+created.gameCanvas = {
+  addEventListener: () => {},
+  getContext: () => ({ clearRect: () => {}, drawImage: () => {} }),
+  style: {}
+};
+
+global.document = { getElementById: id => created[id] };
+global.window = {
+  addEventListener: () => {},
+  innerWidth: 640,
+  innerHeight: 480,
+  requestAnimationFrame: () => {}
+};
+global.requestAnimationFrame = () => {};
+global.localStorage = { getItem: () => null, setItem: () => {} };
+global.Image = function() { return {}; };
+
+const { Game } = require('../src/game');
+
+new Game();
+console.log('Touch binding test stub executed');
+


### PR DESCRIPTION
## Summary
- make canvas responsive
- add touch control buttons to the HTML
- implement bindTouchControls and tap-to-move logic
- style control overlays with transparency
- document mobile controls and workflow updates
- add stub touch test

## Testing
- `node tests/world.js && node tests/upgrade.js && node tests/touch.js`

------
https://chatgpt.com/codex/tasks/task_e_6870e68c226c832b99dc0f3e1466559b