### PR TITLE
Implement DOM-based upgrades and new stats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,4 +15,8 @@ This repository contains an HTML5 game built with vanilla JavaScript.
 - Touch controls are wired in `bindTouchControls()` and rely on IDs defined in
   `index.html`. Ensure any new controls keep to this pattern and maintain
   responsive sizing via `resizeCanvas()`.
+- Upgrades are handled via a DOM overlay with id `upgradeMenu`. `upgrade()`
+  populates this menu using `showUpgradeMenu()` and calculates costs as
+  `baseCost * level` for each stat. Keep new UI elements minimal and reuse this
+  pattern when adding further upgrades.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - Added responsive canvas sizing and mobile touch controls.
 - Documented new control scheme and added test stub for touch bindings.
 
+## [0.4.0] - 2025-07-12
+- Expanded player stats and replaced `prompt` upgrades with a DOM overlay.
+- Added inventory capacity, gas tank mechanic, and cost-scaling tests.
+
 ## [0.2.0] - 2025-07-11
 - Added side-scrolling with expanded world size.
 - Introduced new resources and depth scaling.

--- a/POSTERITY.md
+++ b/POSTERITY.md
@@ -17,3 +17,10 @@ with semi-transparent styling so gameplay remains visible. Canvas dimensions are
 scaled via `resizeCanvas()` to maintain the original aspect ratio on any screen
 size.
 
+## Upgrade menu overlay
+Early versions used the blocking `prompt()` call for upgrades, which halted game
+loop rendering and felt clunky on mobile. The DOM overlay `upgradeMenu` renders
+upgrade choices with their dynamic costs and keeps the canvas visible. This
+pattern keeps the upgrade logic self-contained in `showUpgradeMenu()` and makes
+future expansion straightforward.
+

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
       <button id="btn-upgrade">Upgrade</button>
     </div>
   </div>
+  <div id="upgradeMenu" class="hidden"></div>
   <audio id="sndCollect" src="src/audio/collect.mp3" preload="auto"></audio>
   <audio id="sndDrill" src="src/audio/drill.mp3" preload="auto"></audio>
   <audio id="sndShop" src="src/audio/shop.mp3" preload="auto"></audio>

--- a/src/styles.css
+++ b/src/styles.css
@@ -69,3 +69,18 @@ body {
   flex-direction: column;
   gap: 4px;
 }
+
+#upgradeMenu {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0, 0, 0, 0.8);
+  border: 1px solid #fff;
+  padding: 8px;
+  color: #fff;
+}
+
+#upgradeMenu.hidden {
+  display: none;
+}

--- a/tests/touch.js
+++ b/tests/touch.js
@@ -1,6 +1,6 @@
 // stub document and window before requiring game code
 const created = {};
-['btn-left','btn-right','btn-up','btn-down','btn-dig','btn-refuel','btn-sell','btn-upgrade'].forEach(id => {
+['btn-left','btn-right','btn-up','btn-down','btn-dig','btn-refuel','btn-sell','btn-upgrade','upgradeMenu'].forEach(id => {
   created[id] = { addEventListener: () => {} };
 });
 created.gameCanvas = {

--- a/tests/upgrade.js
+++ b/tests/upgrade.js
@@ -1,8 +1,18 @@
-function upgradeCost(level) {
-  return 100 * level;
+function cost(baseCost, level) {
+  return baseCost * level;
 }
 
-if (upgradeCost(1) !== 100 || upgradeCost(3) !== 300) {
-  throw new Error('Upgrade cost scaling broken');
-}
+const upgrades = {
+  drillSpeed: 100,
+  gasTankSize: 100,
+  hullStrength: 100,
+  liftStrength: 100,
+  storageCapacity: 100
+};
+
+Object.entries(upgrades).forEach(([name, base]) => {
+  if (cost(base, 1) !== base || cost(base, 3) !== base * 3) {
+    throw new Error(`Cost formula broken for ${name}`);
+  }
+});
 console.log('Upgrade cost test passed');


### PR DESCRIPTION
## Summary
- expand player attributes with `drillSpeed`, `gasTankSize`, `hullStrength`, and `storageCapacity`
- cap inventory collection by `storageCapacity`
- add DOM overlay `upgradeMenu` and replace prompt-based upgrade flow
- style overlay in CSS
- adjust tests for new upgrade cost rules
- document upgrade overlay pattern and rationale

## Testing
- `node tests/world.js`
- `node tests/upgrade.js`
- `node tests/touch.js`


------
https://chatgpt.com/codex/tasks/task_e_6870e7f99798832ba11860452923e2d7